### PR TITLE
Add HTTP server to test nodes

### DIFF
--- a/sdk-tutorials/.gitignore
+++ b/sdk-tutorials/.gitignore
@@ -1,0 +1,2 @@
+.python-version
+*.pem

--- a/sdk-tutorials/iperf3-aws-ec2/README.md
+++ b/sdk-tutorials/iperf3-aws-ec2/README.md
@@ -1,6 +1,6 @@
 # Wavelength Testing
 
-This is a CLI tool for deploying test nodes in AWS Wavelength and EC2, and for later tearing them down. The nodes run [`iperf3`](https://iperf.fr/) and [NGINX](http://nginx.org/) to act as test servers.
+This is a CLI tool for deploying test nodes in AWS Wavelength and EC2, and for later tearing them down. The nodes run [`iperf3`](https://iperf.fr/) and [NGINX](https://nginx.org/) to act as test servers.
 
 ## Installation
 

--- a/sdk-tutorials/iperf3-aws-ec2/README.md
+++ b/sdk-tutorials/iperf3-aws-ec2/README.md
@@ -1,6 +1,6 @@
 # Wavelength Testing
 
-This is a CLI tool for deploying test nodes in AWS Wavelength and EC2, and for later tearing them down. The nodes run [`iperf3`](https://iperf.fr/) to act as test servers.
+This is a CLI tool for deploying test nodes in AWS Wavelength and EC2, and for later tearing them down. The nodes run [`iperf3`](https://iperf.fr/) and [NGINX](http://nginx.org/) to act as test servers.
 
 ## Installation
 
@@ -14,7 +14,7 @@ There are two commands: `deploy` and `teardown`. Each takes a `--help` option li
 
 The `deploy` command requires one argument, which is the CIDR notation of which IPs are allowed to connect to the bastion host in EC2. Other options include the `iperf` port, the IPs allowed to connect to the Wavelength instance, and renaming most deployed components.
 
-When finished, the `deploy` command will show an example `ssh` command for acccessing the bastion host, and an example `iperf3` command for testing Wavelength. (Note that the Wavelength node will only be accessible from a device on the Verion cellular network, like a phone or a laptop connected to a hotspot.)
+When finished, the `deploy` command will show an example `ssh` command for acccessing the bastion host, and example `iperf3` and `curl` commands for comparing EC2 and Wavelength. (Note that the Wavelength node will only be accessible from a device on the Verion cellular network, like a phone or a laptop connected to a hotspot.)
 
 ### Teardown
 

--- a/sdk-tutorials/iperf3-aws-ec2/README.md
+++ b/sdk-tutorials/iperf3-aws-ec2/README.md
@@ -23,3 +23,7 @@ The only option for the `teardown` command is the name of the VPC to destroy. If
 ## Author
 
 [Jim Pfleger](https://github.com/codemonkeyjim)
+
+## Acknowledgements
+
+- `curl` timing output from [Simon East via Stack Overflow](https://stackoverflow.com/a/22625150)

--- a/sdk-tutorials/iperf3-aws-ec2/curl-format.txt
+++ b/sdk-tutorials/iperf3-aws-ec2/curl-format.txt
@@ -1,0 +1,8 @@
+     time_namelookup:  %{time_namelookup}s\n
+        time_connect:  %{time_connect}s\n
+     time_appconnect:  %{time_appconnect}s\n
+    time_pretransfer:  %{time_pretransfer}s\n
+       time_redirect:  %{time_redirect}s\n
+  time_starttransfer:  %{time_starttransfer}s\n
+                     ----------\n
+          time_total:  %{time_total}s\n

--- a/sdk-tutorials/iperf3-aws-ec2/requirements.txt
+++ b/sdk-tutorials/iperf3-aws-ec2/requirements.txt
@@ -1,4 +1,5 @@
 boto3
 boto3-stubs[essential]
 mypy
+rich
 typer[all]

--- a/sdk-tutorials/iperf3-aws-ec2/scripts/iperf.sh
+++ b/sdk-tutorials/iperf3-aws-ec2/scripts/iperf.sh
@@ -1,6 +1,0 @@
-#!/bin/bash -xe
-
-sudo su
-yum update -y
-yum install -y iperf3
-iperf3 --server --daemon --port 5001

--- a/sdk-tutorials/iperf3-aws-ec2/scripts/startup.sh
+++ b/sdk-tutorials/iperf3-aws-ec2/scripts/startup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -xe
+
+sudo su
+yum install -y epel-release
+# Updating is very slow (~15 minutes), which confuses users
+# yum update -y
+yum install -y iperf3 nginx
+
+# TODO: templatize and take URL, filename, ports as arguments
+
+nginx
+iperf3 --server --daemon --port 5001
+
+cd /usr/share/nginx/html/ && curl -L -o sample.4ds https://079413ce-bd22-4260-8be6-8b040540a21d.client-api.unity3dusercontent.com/client_api/v1/buckets/6d9e0224-b376-437b-9f0c-ca4cfc1fe443/entries/343a3095-8ceb-4743-b0eb-ffaba39239a5/versions/701327a2-18ea-4942-834c-dac5466a76c2/content/

--- a/sdk-tutorials/iperf3-aws-ec2/scripts/startup.sh
+++ b/sdk-tutorials/iperf3-aws-ec2/scripts/startup.sh
@@ -2,8 +2,7 @@
 
 sudo su
 yum install -y epel-release
-# Updating is very slow (~15 minutes), which confuses users
-# yum update -y
+yum update -y
 yum install -y iperf3 nginx
 
 # TODO: templatize and take URL, filename, ports as arguments


### PR DESCRIPTION
This version installs NGINX on both the EC2 and WL instances, and downloading the file you emailed me. At the end, it prints a sample `curl` command, which uses the included config file for nicer output.

It also adds a status of the instances as they build, which can take up to 15 minutes.